### PR TITLE
Enhancement/#66 Consistent naming in struct serde method and position

### DIFF
--- a/pttbbs/board.go
+++ b/pttbbs/board.go
@@ -176,7 +176,7 @@ func OpenBoardHeaderFile(filename string) ([]*BoardHeader, error) {
 			break
 		}
 
-		f, err := NewBoardHeaderWithByte(hdr)
+		f, err := UnmarshalBoardHeader(hdr)
 		if err != nil {
 			return nil, err
 		}
@@ -261,7 +261,7 @@ func RemoveBoardHeaderFileRecord(filename string, index int) error {
 
 }
 
-func NewBoardHeaderWithByte(data []byte) (*BoardHeader, error) {
+func UnmarshalBoardHeader(data []byte) (*BoardHeader, error) {
 	ret := BoardHeader{}
 
 	ret.BrdName = big5uaoToUTF8String(bytes.Split(data[PosOfBoardName:PosOfBoardName+IDLength+1], []byte("\x00"))[0])

--- a/pttbbs/board.go
+++ b/pttbbs/board.go
@@ -113,7 +113,7 @@ const (
 	PosOfBoardName          = 0
 	PosOfBoardTitle         = PosOfBoardName + IDLength + 1
 	PosOfBM                 = PosOfBoardTitle + BoardTitleLength + 1
-	PosOfBrdAttr            = 3 + IDLength*3 + 3 + PosOfBM
+	PosOfBrdAttr            = 3 + PosOfBM + IDLength*3 + 3
 	PosOfChessCountry       = PosOfBrdAttr + 4
 	PosOfVoteLimitPosts     = PosOfChessCountry + 1
 	PosOfVoteLimitLogins    = PosOfVoteLimitPosts + 1
@@ -126,8 +126,8 @@ const (
 	PosOfPermReload         = PosOfLevel + 4
 	PosOfGid                = PosOfPermReload + 4
 	PosOfNext               = PosOfGid + 4
-	PosOfFirstChild         = PosOfNext + 8
-	PosOfParent             = PosOfFirstChild + 8
+	PosOfFirstChild         = PosOfNext + 4*2
+	PosOfParent             = PosOfFirstChild + 4*2
 	PosOfChildCount         = PosOfParent + 4
 	PosOfNuser              = PosOfChildCount + 4
 	PosOfPostExpire         = PosOfNuser + 4

--- a/pttbbs/cache.go
+++ b/pttbbs/cache.go
@@ -108,22 +108,22 @@ func (c *Cache) caculatePos() {
 	c.posOfSize = c.posOfVersion + 4
 	c.posOfUserID = c.posOfSize + 4
 
-	c.posOfNextInHash = c.posOfUserID + c.MaxUsers*(c.IDLen+1) + (c.IDLen + 1)
+	c.posOfNextInHash = (c.IDLen + 1) + c.posOfUserID + c.MaxUsers*(c.IDLen+1)
 	// Align
 	if c.posOfNextInHash%c.AlignmentBytes != 0 {
 		padding := c.AlignmentBytes - c.posOfNextInHash%c.AlignmentBytes
 		c.posOfNextInHash += padding
 	}
 	fmt.Println("c.posOfNextInHash", c.posOfNextInHash)
-	c.posOfMoney = c.posOfNextInHash + c.MaxUsers*4 + 4 // + gap_2
+	c.posOfMoney = 4 + c.posOfNextInHash + c.MaxUsers*4 // + gap_2
 	if c.UseCoolDown {
-		c.posOfCooldownTime = c.posOfMoney + c.MaxUsers*4 + 4    // + gap_3
-		c.posOfHashHead = c.posOfCooldownTime + c.MaxUsers*4 + 4 // time4_t + gap_4
+		c.posOfCooldownTime = 4 + c.posOfMoney + c.MaxUsers*4    // + gap_3
+		c.posOfHashHead = 4 + c.posOfCooldownTime + c.MaxUsers*4 // + gap_4
 	} else {
-		c.posOfHashHead = c.posOfMoney + c.MaxUsers*4 + 4 + 4 // + gap_3 + gap_4
+		c.posOfHashHead = 4 + 4 + c.posOfMoney + c.MaxUsers*4 // + gap_3 + gap_4
 	}
 
-	c.posOfUserNumber = c.posOfHashHead + (1<<c.HashBits)*4 + 4 // + gap_5
+	c.posOfUserNumber = 4 + c.posOfHashHead + (1<<c.HashBits)*4 // + gap_5
 	c.posOfUserLoaded = c.posOfUserNumber + 4
 
 	c.posOfUserInfo = c.posOfUserLoaded + 4

--- a/pttbbs/fav.go
+++ b/pttbbs/fav.go
@@ -197,17 +197,17 @@ func OpenFavFile(filename string) (*FavFile, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewFavFile(data)
+	return UnmarshalFavFile(data)
 }
 
-// NewFavFile parse data and return FavFile
-func NewFavFile(data []byte) (*FavFile, error) {
+// UnmarshalFavFile parse data and return FavFile
+func UnmarshalFavFile(data []byte) (*FavFile, error) {
 	ret := &FavFile{}
 	size := 2
 	ret.Version = binary.LittleEndian.Uint16(data[0:size])
 
 	var err error
-	ret.Folder, _, err = NewFavFolder(data, size)
+	ret.Folder, _, err = UnmarshalFavFolder(data, size)
 	if err != nil {
 		return nil, err
 	}
@@ -219,9 +219,9 @@ func (favf *FavFolder) getDataNumber() uint16 {
 	return favf.NBoards + uint16(favf.NFolders) + uint16(favf.NLines)
 }
 
-// NewFavFolder takes a []byte, parse it starting with startIndex, return an instance of FavFolder, endIndex
+// UnmarshalFavFolder takes a []byte, parse it starting with startIndex, return an instance of FavFolder, endIndex
 // and error.
-func NewFavFolder(data []byte, startIndex int) (*FavFolder, int, error) {
+func UnmarshalFavFolder(data []byte, startIndex int) (*FavFolder, int, error) {
 	// data must at least has 4 bytes for a new FavFolder
 	if len(data) < startIndex+4 {
 		return nil, startIndex, ErrIndexOutOfBound
@@ -253,7 +253,7 @@ func NewFavFolder(data []byte, startIndex int) (*FavFolder, int, error) {
 	// There are itemCount items, parse and insert them one by one
 	for itemCount > 0 {
 		n := len(ret.FavItems) - int(itemCount) // calculate index
-		ret.FavItems[n], c, err = NewFavItem(data, c)
+		ret.FavItems[n], c, err = UnmarshalFavItem(data, c)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -264,7 +264,7 @@ func NewFavFolder(data []byte, startIndex int) (*FavFolder, int, error) {
 	for _, item := range ret.FavItems {
 		if f, ok := item.Item.(*FavFolderItem); ok {
 			var nextFolder *FavFolder
-			nextFolder, c, err = NewFavFolder(data, c)
+			nextFolder, c, err = UnmarshalFavFolder(data, c)
 			if err != nil {
 				return nil, c, err
 			}
@@ -281,9 +281,9 @@ func NewFavFolder(data []byte, startIndex int) (*FavFolder, int, error) {
 	return ret, c, nil
 }
 
-// NewFavItem parse data starting from startIndex and return FavItem. FavItem.Item might be either FavBoardItem,
+// UnmarshalFavItem parse data starting from startIndex and return FavItem. FavItem.Item might be either FavBoardItem,
 // FavFolderItem or FavLineItem
-func NewFavItem(data []byte, startIndex int) (*FavItem, int, error) {
+func UnmarshalFavItem(data []byte, startIndex int) (*FavItem, int, error) {
 	// data at least must have 2 bytes for a new FavItem
 	if len(data) < startIndex+2 {
 		return nil, startIndex, ErrIndexOutOfBound
@@ -304,11 +304,11 @@ func NewFavItem(data []byte, startIndex int) (*FavItem, int, error) {
 
 	switch ret.FavType {
 	case FavItemTypeBoard:
-		item, c, err = NewFavBoardItem(data, c)
+		item, c, err = UnmarshalFavBoardItem(data, c)
 	case FavItemTypeLine:
-		item, c, err = NewFavLineItem(data, c)
+		item, c, err = UnmarshalFavLineItem(data, c)
 	case FavItemTypeFolder:
-		item, c, err = NewFavFolderItem(data, c)
+		item, c, err = UnmarshalFavFolderItem(data, c)
 	default:
 		err = ErrInvalidFavType
 	}
@@ -320,8 +320,8 @@ func NewFavItem(data []byte, startIndex int) (*FavItem, int, error) {
 	return ret, c, err
 }
 
-// NewFavBoardItem takes a []byte and parse it starting from startIndex, return FavBoardItem, end index and error
-func NewFavBoardItem(data []byte, startIndex int) (*FavBoardItem, int, error) {
+// UnmarshalFavBoardItem takes a []byte and parse it starting from startIndex, return FavBoardItem, end index and error
+func UnmarshalFavBoardItem(data []byte, startIndex int) (*FavBoardItem, int, error) {
 	if len(data) < startIndex+sizeOfPttFavBoardBytes {
 		return nil, startIndex, ErrIndexOutOfBound
 	}
@@ -346,8 +346,8 @@ func NewFavBoardItem(data []byte, startIndex int) (*FavBoardItem, int, error) {
 	return ret, c, nil
 }
 
-// NewFavFolderItem takes a []byte and parse it starting from startIndex, return FavFolderItem, end index and error
-func NewFavFolderItem(data []byte, startIndex int) (*FavFolderItem, int, error) {
+// UnmarshalFavFolderItem takes a []byte and parse it starting from startIndex, return FavFolderItem, end index and error
+func UnmarshalFavFolderItem(data []byte, startIndex int) (*FavFolderItem, int, error) {
 	if len(data) < startIndex+sizeOfPttFavFolderBytes {
 		return nil, startIndex, ErrIndexOutOfBound
 	}
@@ -365,8 +365,8 @@ func NewFavFolderItem(data []byte, startIndex int) (*FavFolderItem, int, error) 
 	return ret, c, nil
 }
 
-// NewFavLineItem takes a []byte and parse it starting from startIndex, return FavLineItem, end index and error
-func NewFavLineItem(data []byte, startIndex int) (*FavLineItem, int, error) {
+// UnmarshalFavLineItem takes a []byte and parse it starting from startIndex, return FavLineItem, end index and error
+func UnmarshalFavLineItem(data []byte, startIndex int) (*FavLineItem, int, error) {
 	if len(data) < startIndex+sizeOfPttFavLineBytes {
 		return nil, startIndex, ErrIndexOutOfBound
 	}

--- a/pttbbs/fav_test.go
+++ b/pttbbs/fav_test.go
@@ -26,9 +26,9 @@ import (
 
 var time0 = time.Unix(int64(0), 0)
 
-func TestNewFavLineItem(t *testing.T) {
+func TestUnmarshalFavItem(t *testing.T) {
 	data := []byte{3, 1, 2}
-	item, _, err := NewFavItem(data, 0)
+	item, _, err := UnmarshalFavItem(data, 0)
 	if err != nil || item == nil {
 		t.Fatal("Failed to parse Line")
 	}

--- a/pttbbs/passwd.go
+++ b/pttbbs/passwd.go
@@ -32,25 +32,25 @@ const (
 	PosOfPasswdRealName     = PosOfPasswdUserID + IDLength + 1
 	PosOfPasswdNickname     = PosOfPasswdRealName + RealNameSize
 	PosOfPasswdPassword     = PosOfPasswdNickname + NicknameSize
-	PosOfPasswdUserFlag     = PosOfPasswdPassword + PasswordLength + 1
-	PosOfPasswdUserLevel    = PosOfPasswdUserFlag + 4 + 4
+	PosOfPasswdUserFlag     = 1 + PosOfPasswdPassword + PasswordLength
+	PosOfPasswdUserLevel    = 4 + PosOfPasswdUserFlag + 4
 	PosOfPasswdNumLoginDays = PosOfPasswdUserLevel + 4
 	PosOfPasswdNumPosts     = PosOfPasswdNumLoginDays + 4
 	PosOfPasswdFirstLogin   = PosOfPasswdNumPosts + 4
 	PosOfPasswdLastLogin    = PosOfPasswdFirstLogin + 4
 	PosOfPasswdLastHost     = PosOfPasswdLastLogin + 4
 	PosOfPasswdMoney        = PosOfPasswdLastHost + IPV4Length + 1
-	PosOfPasswdEmail        = PosOfPasswdMoney + 4 + 4
+	PosOfPasswdEmail        = 4 + PosOfPasswdMoney + 4
 	PosOfPasswdAddress      = PosOfPasswdEmail + EmailSize
 	PosOfPasswdJustify      = PosOfPasswdAddress + AddressSize
-	PosOfPasswdOver18       = PosOfPasswdJustify + RegistrationLength + 1 + 3
+	PosOfPasswdOver18       = 3 + PosOfPasswdJustify + RegistrationLength + 1
 	PosOfPasswdPagerUIType  = PosOfPasswdOver18 + 1
 	PosOfPasswdPager        = PosOfPasswdPagerUIType + 1
 	PosOfPasswdInvisible    = PosOfPasswdPager + 1
-	PosOfPasswdExMailBox    = PosOfPasswdInvisible + 1 + 2
+	PosOfPasswdExMailBox    = 2 + PosOfPasswdInvisible + 1
 
-	PosOfPasswdCareer        = PosOfPasswdExMailBox + 4 + 4
-	PosOfPasswdRole          = PosOfPasswdCareer + CareerSize + 20 + 4 + 44
+	PosOfPasswdCareer        = 4 + PosOfPasswdExMailBox + 4
+	PosOfPasswdRole          = 20 + 4 + 44 + PosOfPasswdCareer + CareerSize
 	PosOfPasswdLastSeen      = PosOfPasswdRole + 4
 	PosOfPasswdTimeSetAngel  = PosOfPasswdLastSeen + 4
 	PosOfPasswdTimePlayAngel = PosOfPasswdTimeSetAngel + 4
@@ -58,7 +58,7 @@ const (
 	PosOfPasswdLastSong  = PosOfPasswdTimePlayAngel + 4
 	PosOfPasswdLoginView = PosOfPasswdLastSong + 4
 
-	PosOfPasswdLawCounter = PosOfPasswdLoginView + 4 + 2
+	PosOfPasswdLawCounter = 1 + 1 + PosOfPasswdLoginView + 4
 	PosOfPasswdFiveWin    = PosOfPasswdLawCounter + 2
 	PosOfPasswdFiveLose   = PosOfPasswdFiveWin + 2
 	PosOfPasswdFiveTie    = PosOfPasswdFiveLose + 2
@@ -68,7 +68,7 @@ const (
 	PosOfPasswdConn6Win   = PosOfPasswdChcTie + 2
 	PosOfPasswdConn6Lose  = PosOfPasswdConn6Win + 2
 	PosOfPasswdConn6Tie   = PosOfPasswdConn6Lose + 2
-	PosOfPasswdGoWin      = PosOfPasswdConn6Tie + 2 + 2
+	PosOfPasswdGoWin      = 2 + PosOfPasswdConn6Tie + 2
 	PosOfPasswdGoLose     = PosOfPasswdGoWin + 2
 	PosOfPasswdGoTie      = PosOfPasswdGoLose + 2
 	PosOfPasswdDarkWin    = PosOfPasswdGoTie + 2
@@ -76,11 +76,11 @@ const (
 	PosOfPasswdUaVersion  = PosOfPasswdDarkLose + 2
 
 	PosOfPasswdSignature = PosOfPasswdUaVersion + 1
-	PosOfPasswdBadPost   = PosOfPasswdSignature + 1 + 1
+	PosOfPasswdBadPost   = 1 + PosOfPasswdSignature + 1
 	PosOfPasswdDarkTie   = PosOfPasswdBadPost + 1
 	PosOfPasswdMyAngel   = PosOfPasswdDarkTie + 2
 
-	PosOfPasswdChessEloRating    = PosOfPasswdMyAngel + IDLength + 1 + 1
+	PosOfPasswdChessEloRating    = 1 + PosOfPasswdMyAngel + IDLength + 1
 	PosOfPasswdWithMe            = PosOfPasswdChessEloRating + 2
 	PosOfPasswdTimeRemoveBadPost = PosOfPasswdWithMe + 4
 	PosOfPasswdTimeViolateLaw    = PosOfPasswdTimeRemoveBadPost + 4

--- a/pttbbs/passwd.go
+++ b/pttbbs/passwd.go
@@ -211,7 +211,7 @@ func OpenUserecFile(filename string) ([]*Userec, error) {
 			break
 		}
 
-		f, err := NewUserecWithByte(buf)
+		f, err := UnmarshalUserec(buf)
 		if err != nil {
 			return nil, err
 		}
@@ -224,7 +224,7 @@ func OpenUserecFile(filename string) ([]*Userec, error) {
 
 }
 
-func NewUserecWithByte(data []byte) (*Userec, error) {
+func UnmarshalUserec(data []byte) (*Userec, error) {
 	user := &Userec{}
 	user.Version = binary.LittleEndian.Uint32(data[PosOfPasswdVersion : PosOfPasswdVersion+4])
 	user.userID = newStringFormCString(data[PosOfPasswdUserID : PosOfPasswdUserID+IDLength+1])
@@ -296,7 +296,7 @@ func NewUserecWithByte(data []byte) (*Userec, error) {
 	return user, nil
 }
 
-func (u *Userec) MarshalToByte() ([]byte, error) {
+func (u *Userec) MarshalBinary() ([]byte, error) {
 	ret := make([]byte, 512)
 
 	binary.LittleEndian.PutUint32(ret[PosOfPasswdVersion:PosOfPasswdVersion+4], u.Version)

--- a/pttbbs/passwd.go
+++ b/pttbbs/passwd.go
@@ -301,7 +301,7 @@ func (u *Userec) MarshalBinary() ([]byte, error) {
 
 	binary.LittleEndian.PutUint32(ret[PosOfPasswdVersion:PosOfPasswdVersion+4], u.Version)
 	copy(ret[PosOfPasswdUserID:PosOfPasswdUserID+IDLength+1], utf8ToBig5UAOString(u.userID))
-	copy(ret[PosOfPasswdRealName:PosOfPasswdRealName+IDLength+1], utf8ToBig5UAOString(u.realName))
+	copy(ret[PosOfPasswdRealName:PosOfPasswdRealName+RealNameSize], utf8ToBig5UAOString(u.realName))
 	copy(ret[PosOfPasswdNickname:PosOfPasswdNickname+NicknameSize], utf8ToBig5UAOString(u.nickname))
 	copy(ret[PosOfPasswdPassword:PosOfPasswdPassword+PasswordLength], utf8ToBig5UAOString(u.password))
 

--- a/pttbbs/passwd_test.go
+++ b/pttbbs/passwd_test.go
@@ -526,7 +526,7 @@ func TestOpenUserecFile(t *testing.T) {
 
 }
 
-func TestEncodingUserec(t *testing.T) {
+func TestMarshalBinaryUserec(t *testing.T) {
 	type TestCase struct {
 		Input    Userec
 		Expected []byte
@@ -627,7 +627,7 @@ b36e c5e9 0000 0000 0000 0000 0000 0000
 	}
 
 	for index, c := range testcase {
-		b, err := c.Input.MarshalToByte()
+		b, err := c.Input.MarshalBinary()
 		t.Logf("log: %q, %q", b, err)
 		if hex.Dump(b) != hex.Dump(c.Expected) {
 			t.Errorf("Expected byte not match in index %d, expected: \n%s\n, got: \n%s", index, hex.Dump(c.Expected), hex.Dump(b))


### PR DESCRIPTION
<!-- 原則上不接受沒有 Issue ID 的 PR。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決掉的 issue / Resolved Issues
- close #66 

## ⛏ 變更內容 / Details of Changes
<!-- 簡要陳列您的修改 -->
<!-- List down your changes concisely -->
- 針對PosOf重新調整成 `前面padding長 + 前一個PosOf + 前一個欄位長度`
- 將物件序列化及反序列化統一命名成 `Unmarshal + structName`與`MarshalBinary`與使用介面一致
