### PR TITLE
Feature/#86 實作個人看板的歷史留言

### DIFF
--- a/ansi.go
+++ b/ansi.go
@@ -1,0 +1,26 @@
+package bbs
+
+import (
+	"bytes"
+	"regexp"
+	"unsafe"
+)
+
+const ansi = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
+
+var re = regexp.MustCompile(ansi)
+
+func FilterANSI(dst, src []byte) []byte {
+	out := re.ReplaceAllString(ToString(src), "")
+	copy(dst[:], out)
+	firstNull := bytes.IndexAny(dst, "\x00")
+	return dst[:firstNull]
+}
+
+func FilterStringANSI(src string) string {
+	return re.ReplaceAllString(src, "")
+}
+
+func ToString(b []byte) string {
+	return *(*string)(unsafe.Pointer(&b))
+}

--- a/ansi.go
+++ b/ansi.go
@@ -1,7 +1,6 @@
 package bbs
 
 import (
-	"bytes"
 	"regexp"
 	"unsafe"
 )
@@ -9,13 +8,6 @@ import (
 const ansi = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
 
 var re = regexp.MustCompile(ansi)
-
-func FilterANSI(dst, src []byte) []byte {
-	out := re.ReplaceAllString(ToString(src), "")
-	copy(dst[:], out)
-	firstNull := bytes.IndexAny(dst, "\x00")
-	return dst[:firstNull]
-}
 
 func FilterStringANSI(src string) string {
 	return re.ReplaceAllString(src, "")

--- a/ansi.go
+++ b/ansi.go
@@ -2,7 +2,6 @@ package bbs
 
 import (
 	"regexp"
-	"unsafe"
 )
 
 const ansi = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
@@ -11,8 +10,4 @@ var re = regexp.MustCompile(ansi)
 
 func FilterStringANSI(src string) string {
 	return re.ReplaceAllString(src, "")
-}
-
-func ToString(b []byte) string {
-	return *(*string)(unsafe.Pointer(&b))
 }

--- a/ansi_test.go
+++ b/ansi_test.go
@@ -1,22 +1,9 @@
 package bbs
 
 import (
-	"bytes"
 	"strings"
 	"testing"
 )
-
-func TestFilterANSI(t *testing.T) {
-	src := []byte("[1;31m→ [33mpichu2[m[33m:推")
-	dst := make([]byte, len(src))
-	expected := []byte("→ pichu2:推")
-
-	dst = FilterANSI(dst, src)
-
-	if bytes.Compare(expected, dst) != 0 {
-		t.Errorf("FilterANSI doesn't filter the ANSI code, \nexpected: \n%s, \ngot: \n%s", expected, dst)
-	}
-}
 
 func TestFilterStringANSI(t *testing.T) {
 	src := "[1;31m→ [33mpichu2[m[33m:推"
@@ -29,13 +16,12 @@ func TestFilterStringANSI(t *testing.T) {
 	}
 }
 
-func BenchmarkReflect(b *testing.B) {
-	src := []byte("[1;31m→ [33mpichu2[m[33m:推")
-	dst := make([]byte, len(src))
+func BenchmarkStringANSI(b *testing.B) {
+	src := "[1;31m→ [33mpichu2[m[33m:推"
 
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		FilterANSI(dst, src)
+		_ = FilterStringANSI(src)
 	}
 }

--- a/ansi_test.go
+++ b/ansi_test.go
@@ -1,0 +1,41 @@
+package bbs
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestFilterANSI(t *testing.T) {
+	src := []byte("[1;31m→ [33mpichu2[m[33m:推")
+	dst := make([]byte, len(src))
+	expected := []byte("→ pichu2:推")
+
+	dst = FilterANSI(dst, src)
+
+	if bytes.Compare(expected, dst) != 0 {
+		t.Errorf("FilterANSI doesn't filter the ANSI code, \nexpected: \n%s, \ngot: \n%s", expected, dst)
+	}
+}
+
+func TestFilterStringANSI(t *testing.T) {
+	src := "[1;31m→ [33mpichu2[m[33m:推"
+	expected := "→ pichu2:推"
+
+	dst := FilterStringANSI(src)
+
+	if strings.Compare(expected, dst) != 0 {
+		t.Errorf("FilterStringANSI doesn't filter ANSI CSI code, \nexpected: \n%s, \ngot: \n%s", expected, dst)
+	}
+}
+
+func BenchmarkReflect(b *testing.B) {
+	src := []byte("[1;31m→ [33mpichu2[m[33m:推")
+	dst := make([]byte, len(src))
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		FilterANSI(dst, src)
+	}
+}

--- a/ansi_test.go
+++ b/ansi_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 )
 
+const strWithANSI = "\x1b[1;31m→ \x1b[33mpichu2\x1b[m\x1b[33m:推"
+
 func TestFilterStringANSI(t *testing.T) {
-	src := "[1;31m→ [33mpichu2[m[33m:推"
+	src := strWithANSI
 	expected := "→ pichu2:推"
 
 	dst := FilterStringANSI(src)
@@ -17,7 +19,7 @@ func TestFilterStringANSI(t *testing.T) {
 }
 
 func BenchmarkStringANSI(b *testing.B) {
-	src := "[1;31m→ [33mpichu2[m[33m:推"
+	src := strWithANSI
 
 	b.ResetTimer()
 

--- a/bbs.go
+++ b/bbs.go
@@ -569,7 +569,7 @@ func (db *DB) GetBoardArticleCommentRecords(boardID, filename string) (crs []Use
 	}
 
 	floorCnt := uint32(1)
-	scanner := bufio.NewScanner(strings.NewReader(ToString(content)))
+	scanner := bufio.NewScanner(strings.NewReader(string(content)))
 	for scanner.Scan() {
 		l := FilterStringANSI(scanner.Text())
 		cr, err := NewUserCommentRecord(floorCnt, l)

--- a/bbs_test.go
+++ b/bbs_test.go
@@ -1,0 +1,179 @@
+package bbs
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func TestGetBoardArticleCommentRecords(t *testing.T) {
+
+	anyBoardID := ""
+	anyFilename := ""
+	articleContent := `
+a740 aacc 3a20 5359 534f 5020 28af ab29
+20ac ddaa 4f3a 2074 6573 740a bcd0 c344
+3a20 5bb0 ddc3 445d 2054 6869 7320 506f
+7374 2077 696c 6c20 6265 2069 6e20 6d61
+6e0a aec9 b6a1 3a20 5361 7420 4a61 6e20
+2039 2031 393a 3032 3a31 3220 3230 3231
+0a0a 0a54 6573 740a 0a2d 2d0a a1b0 20b5
+6fab 48af b83a 20b7 73a7 e5bd f0bd f028
+7074 7432 2e63 6329 2c20 a8d3 a6db 3a20
+312e 3136 342e 3131 312e 3135 360a a1b0
+20a4 e5b3 b9ba f4a7 7d3a 2068 7474 703a
+2f2f 7777 772e 7074 742e 6363 2f62 6273
+2f74 6573 742f 4d2e 3136 3130 3231 3839
+3334 2e41 2e46 4130 2e68 746d 6c0a 1b5b
+313b 3331 6da1 f720 1b5b 3333 6d53 5953
+4f50 1b5b 6d1b 5b33 336d 3a50 7573 6820
+2020 2020 2020 2020 2020 2020 2020 2020
+2020 2020 2020 2020 2020 2020 2020 2020
+2020 2020 2020 2020 2020 2020 2020 2020
+2020 1b5b 6db1 c020 3031 2f30 3920 3139
+3a30 320a 1b5b 313b 3331 6da1 f720 1b5b
+3333 6d53 5953 4f50 1b5b 6d1b 5b33 336d
+3a74 6573 7420 2020 2020 2020 2020 2020
+2020 2020 2020 2020 2020 2020 2020 2020
+2020 2020 2020 2020 2020 2020 2020 2020
+2020 2020 2020 2020 1b5b 6db1 c020 3031
+2f31 3720 3131 3a33 360a a1b0 201b 5b31
+3b33 326d 7069 6368 7532 1b5b 303b 3332
+6d3a c2e0 bffd a6dc acdd aa4f 2053 5953
+4f50 1b5b 6d20 2020 2020 2020 2020 2020
+2020 2020 2020 2020 2020 2020 2020 2020
+2020 2020 2031 3131 2e32 3438 2e34 372e
+3136 3420 3031 2f32 370a`
+
+	returnPerfectBoardArticleFilePath := func() (string, error) {
+		return anyBoardID, nil
+	}
+	returnPerfectReadBoardArticleFile := func() ([]byte, error) {
+		return hexToByte(articleContent), nil
+	}
+
+	type fields struct {
+		connector Connector
+	}
+	type args struct {
+		boardID  string
+		filename string
+	}
+	type expected struct {
+		recordCount int
+		hasErr      bool
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		args     args
+		expected expected
+	}{
+		{
+			name: "parse an article contains two user comments",
+			fields: fields{
+				connector: &fakeConnector{
+					fakeGetBoardArticleFilePath: returnPerfectBoardArticleFilePath,
+					fakeReadBoardArticleFile:    returnPerfectReadBoardArticleFile,
+				},
+			},
+			args:     args{anyBoardID, anyFilename},
+			expected: expected{2, false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := &DB{connector: tt.fields.connector}
+
+			got, err := db.GetBoardArticleCommentRecords(tt.args.boardID, tt.args.filename)
+
+			if len(got) != tt.expected.recordCount {
+				t.Errorf("record count = %v, expected %v\n", len(got), tt.expected.recordCount)
+			}
+
+			if (err != nil) != tt.expected.hasErr {
+				t.Errorf("err = %v, should be nil\n", err)
+			}
+		})
+	}
+
+}
+
+type fakeConnector struct {
+	fakeOpen                        func() error
+	fakeGetUserRecordsPath          func() (string, error)
+	fakeReadUserRecordsFile         func() ([]UserRecord, error)
+	fakeGetUserFavoriteRecordsPath  func() (string, error)
+	fakeReadUserFavoriteRecordsFile func() ([]FavoriteRecord, error)
+	fakeGetBoardRecordsPath         func() (string, error)
+	fakeReadBoardRecordsFile        func() ([]BoardRecord, error)
+	fakeGetBoardArticleRecordsPath  func() (string, error)
+	fakeGetBoardTreasureRecordsPath func() (string, error)
+	fakeReadArticleRecordsFile      func() ([]ArticleRecord, error)
+	fakeGetBoardArticleFilePath     func() (string, error)
+	fakeGetBoardTreasureFilePath    func() (string, error)
+	fakeReadBoardArticleFile        func() ([]byte, error)
+}
+
+var _ Connector = &fakeConnector{}
+
+func (c *fakeConnector) Open(dataSourceName string) error {
+	return c.fakeOpen()
+}
+
+func (c *fakeConnector) GetUserRecordsPath() (string, error) {
+	return c.fakeGetUserRecordsPath()
+}
+
+func (c *fakeConnector) ReadUserRecordsFile(name string) ([]UserRecord, error) {
+	return c.fakeReadUserRecordsFile()
+}
+
+func (c *fakeConnector) GetUserFavoriteRecordsPath(userID string) (string, error) {
+	return c.fakeGetUserFavoriteRecordsPath()
+}
+
+func (c *fakeConnector) ReadUserFavoriteRecordsFile(name string) ([]FavoriteRecord, error) {
+	return c.fakeReadUserFavoriteRecordsFile()
+}
+
+func (c *fakeConnector) GetBoardRecordsPath() (string, error) {
+	return c.fakeGetBoardRecordsPath()
+}
+
+func (c *fakeConnector) ReadBoardRecordsFile(name string) ([]BoardRecord, error) {
+	return c.fakeReadBoardRecordsFile()
+}
+
+func (c *fakeConnector) GetBoardArticleRecordsPath(boardID string) (string, error) {
+	return c.fakeGetBoardArticleRecordsPath()
+}
+
+func (c *fakeConnector) GetBoardTreasureRecordsPath(boardID string, treasureID []string) (string, error) {
+	return c.fakeGetBoardTreasureRecordsPath()
+}
+
+func (c *fakeConnector) ReadArticleRecordsFile(name string) ([]ArticleRecord, error) {
+	return c.fakeReadArticleRecordsFile()
+}
+
+func (c *fakeConnector) GetBoardArticleFilePath(boardID string, filename string) (string, error) {
+	return c.fakeGetBoardArticleFilePath()
+}
+
+func (c *fakeConnector) GetBoardTreasureFilePath(boardID string, treasureID []string, name string) (string, error) {
+	return c.fakeGetBoardTreasureFilePath()
+}
+
+func (c *fakeConnector) ReadBoardArticleFile(name string) ([]byte, error) {
+	return c.fakeReadBoardArticleFile()
+}
+
+func hexToByte(input string) []byte {
+	s := strings.ReplaceAll(input, " ", "")
+	s = strings.ReplaceAll(s, "\t", "")
+	s = strings.ReplaceAll(s, "\n", "")
+	b, _ := hex.DecodeString(s)
+	return b
+}

--- a/cmd/bbstool/main.go
+++ b/cmd/bbstool/main.go
@@ -39,6 +39,10 @@ func main() {
 		// Example: go run ./  --bbshome=../../home/bbs showuserarticlelist --user_id pichu
 		showuserarticlelist()
 		return
+	case "showusercommentlist":
+		// Example: go run ./  --bbshome=../../home/bbs showusercommentlist --user_id pichu -board t
+		showusercommentlist()
+		return
 	}
 
 }
@@ -185,7 +189,7 @@ func showuserarticlelist() {
 
 	records, err := bbsDB.GetUserArticleRecordFile(args["user_id"].(string))
 	if err != nil {
-		fmt.Printf("showuserarticlelist: ReadUserRecords: %v\n", err)
+		fmt.Printf("showuserarticlelist: GetUserArticleRecordFile: %v\n", err)
 		return
 	}
 
@@ -196,4 +200,31 @@ func showuserarticlelist() {
 		fmt.Println("titlex:", r.Title())
 	}
 
+}
+
+func showusercommentlist() {
+	err := chkIsDir(bbshome)
+	if err != nil {
+		fmt.Printf("showusercommentlist: error: %v\n", err)
+		return
+	}
+
+	bbsDB, err := bbs.Open(driverName, "file://"+bbshome)
+	if err != nil {
+		fmt.Printf("showusercommentlist: open db: %v\n", err)
+		return
+	}
+
+	args := parseArgsToMap(flag.Args())
+	userID := args["user_id"].(string)
+
+	records, err := bbsDB.GetUserCommentRecordFile(userID)
+	if err != nil {
+		fmt.Printf("showusercommentlist: GetUserCommentRecordFile: %v\n", err)
+		return
+	}
+
+	for _, r := range records {
+		fmt.Println("user comment record:", r.String())
+	}
 }

--- a/user_comment_record.go
+++ b/user_comment_record.go
@@ -1,0 +1,91 @@
+package bbs
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+)
+
+var (
+	ErrNotUserComment         = fmt.Errorf("data is not a user comment")
+	ErrUserCommentEmptyUserID = fmt.Errorf("user comment has empty name")
+)
+
+var (
+	userCommentPattern = regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9]+):.*([0-9][0-9]\/[0-9][0-9]\s[0-9][0-9]:[0-9][0-9])`)
+)
+
+type UserCommentRecord interface {
+	CommentOrder() uint32
+	CommentOwner() string
+	CommentTime() time.Time
+	String() string
+}
+
+var _ UserCommentRecord = &userCommentRecord{}
+
+type userCommentRecord struct {
+	commentOrder uint32
+	commentOwner string
+	commentTime  time.Time
+}
+
+// NewUserCommentRecord parses the data and returns the user comment record.
+//  Return error when input data is not matched the user comment pattern.
+func NewUserCommentRecord(order uint32, data string) (UserCommentRecord, error) {
+	owner, ctime, err := parseUserComment(data)
+	if err != nil {
+		return nil, err
+	}
+	return &userCommentRecord{
+		commentOrder: order,
+		commentOwner: owner,
+		commentTime:  ctime,
+	}, nil
+}
+
+func (r userCommentRecord) CommentOrder() uint32 {
+	return r.commentOrder
+}
+
+func (r userCommentRecord) CommentOwner() string {
+	return r.commentOwner
+}
+
+func (r userCommentRecord) CommentTime() time.Time {
+	return r.commentTime
+}
+
+func (r userCommentRecord) String() string {
+	return fmt.Sprintf("order: %d, owner: %s, time: %s", r.commentOrder, r.commentOwner, r.commentTime.Format("01/02 15:04"))
+}
+
+// parseUserComment returns the owner and time of comment data.
+//  Return ErrNotUserComment error when data doesn't match to the pattern.
+//  Return other error when data contains the ambiguous value which can't parse.
+func parseUserComment(data string) (owner string, ctime time.Time, err error) {
+	matches := userCommentPattern.FindStringSubmatch(data)
+	// The 1st record is entire matched result of row.
+	// The 2nd record is group owner result, EX: "pichu".
+	const ownerIdx = 1
+	// The 3rd record is group time result,  EX: "05/15 01:06".
+	const timeIdx = 2
+	if len(matches) < 3 {
+		err = ErrNotUserComment
+		return
+	}
+
+	owner = matches[ownerIdx]
+	if len(owner) == 0 {
+		err = ErrUserCommentEmptyUserID
+		return
+	}
+
+	ctimeStr := matches[timeIdx]
+	ctime, err = time.Parse("01/02 15:04", ctimeStr)
+	if err != nil {
+		return
+	}
+
+	return owner, ctime, nil
+}

--- a/user_comment_record_test.go
+++ b/user_comment_record_test.go
@@ -1,0 +1,96 @@
+package bbs
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewUserCommentRecord(t *testing.T) {
+	perfectData := "→ lex: 快一點                        05/15 01:06"
+	expectedOrder := uint32(1)
+	expectedOwner := "lex"
+	expectedTime := time.Date(0, 5, 15, 1, 6, 0, 0, time.UTC)
+
+	got, err := NewUserCommentRecord(1, perfectData)
+
+	if got.CommentOrder() != expectedOrder {
+		t.Errorf("comment order = %v, expected %v\n", got.CommentOrder(), expectedOrder)
+	}
+
+	if strings.Compare(got.CommentOwner(), expectedOwner) != 0 {
+		t.Errorf("comment owner = %v, expected %v\n", got.CommentOwner(), expectedOwner)
+	}
+
+	if !got.CommentTime().Equal(expectedTime) {
+		t.Errorf("comment time = %v, expected %v\n", got.CommentTime(), expectedTime)
+	}
+
+	if err != nil {
+		t.Errorf("err = %v, should be nil\n", err)
+	}
+}
+
+func TestParseUserComment(t *testing.T) {
+
+	expectedTime := time.Date(0, 5, 15, 1, 6, 0, 0, time.UTC)
+	emptyTime := time.Time{}
+
+	perfectData := "→ lex: 快一點                        05/15 01:06"
+	dataWithoutOwner := ": 快一點                             05/15 01:06"
+	dataWithInvalidTime := "→ lex: 快一點                        5/15 01:06"
+	emptyData := ""
+
+	type args struct {
+		data string
+	}
+	type expected struct {
+		owner  string
+		ctime  time.Time
+		hasErr bool
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected expected
+	}{
+		{
+			name:     "parse perfect data",
+			args:     args{perfectData},
+			expected: expected{"lex", expectedTime, false},
+		},
+		{
+			name:     "parse data without owner should return error",
+			args:     args{dataWithoutOwner},
+			expected: expected{"", emptyTime, true},
+		},
+		{
+			name:     "parse data with invalid time should return error",
+			args:     args{dataWithInvalidTime},
+			expected: expected{"", emptyTime, true},
+		},
+		{
+			name:     "parse empty data should return error",
+			args:     args{emptyData},
+			expected: expected{"", emptyTime, true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOwner, gotTime, gotErr := parseUserComment(tt.args.data)
+
+			if strings.Compare(gotOwner, tt.expected.owner) != 0 {
+				t.Errorf("comment owner = %v, expected %v\n", gotOwner, tt.expected.owner)
+			}
+
+			if !gotTime.Equal(tt.expected.ctime) {
+				t.Errorf("comment time = %v, expected %v\n", gotTime, tt.expected.ctime)
+			}
+
+			if (gotErr != nil) != tt.expected.hasErr {
+				t.Errorf("err = %v, should be nil\n", gotErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 👏 解決掉的 issue / Resolved Issues
- close #86 

## 📝 相關的 issue / Related Issues
- #86 

## ⛏ 變更內容 / Details of Changes
- 新增 user_comment_record.go
  - NewUserCommentRecord 可判斷傳入的資料是否符合留言的格式，並從符合格式的資料中擷取留言者與時間。
- 新增 ansi.go
  - 小工具可以將 ANSI escape code 移除。
- 修改 bbs.go
  - 新增 UserCommentConnector interface 處理個人留言的快取(未實作細節)。
  - 新增 GetUserCommentRecordFile method 從所有開板中找出使用者的歷史留言。
  - 新增 GetBoardUserCommentRecord method 從特定看板中找出使用者的歷史留言。
  - 新增 GetBoardArticleCommentRecords method 從特定文章中找出所有使用者的留言。
  - 新增 bbs_test.go 利用 fakeConnector 模擬實際存取檔案的功能，藉此完成 DB 邏輯的測試。
